### PR TITLE
Fixed update for absent .desktop file

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -166,22 +166,25 @@ function patchDesktopFile(desktopFileContent) {
   }
 
   return new Promise((resolve, reject) => {
-    fs.readFile(desktopFilePath, 'utf8', (err, originalContent) => {
-      if (err) {
-        return reject(err);
-      }
-
-      originalContent = originalContent
-        .replace(VERSION_MATCH, 'X-AppImage-Version=' + version)
-        .replace(BUNDLE_ID_MATCH, 'X-AppImage-BuildId=' + bundleId);
-
-      fs.writeFile(desktopFilePath, originalContent, (err) => {
+    if (fs.existsSync(desktopFilePath)) {
+      fs.readFile(desktopFilePath, 'utf8', (err, originalContent) => {
         if (err) {
           return reject(err);
         }
 
-        resolve();
+        originalContent = originalContent
+          .replace(VERSION_MATCH, 'X-AppImage-Version=' + version)
+          .replace(BUNDLE_ID_MATCH, 'X-AppImage-BuildId=' + bundleId);
+
+        fs.writeFile(desktopFilePath, originalContent, (err) => {
+          if (err) {
+            return reject(err);
+          }
+
+          resolve();
+        });
       });
-    });
+    }
+    resolve();
   });
 }

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -157,7 +157,6 @@ function patchDesktopFile(desktopFileContent) {
   const VERSION_MATCH = /X-AppImage-Version=(\d+\.\d+\.\d+)/;
   const BUNDLE_ID_MATCH = /X-AppImage-BuildId=([\w-]+)/;
 
-
   const version = desktopFileContent.match(VERSION_MATCH)[1];
   const bundleId = desktopFileContent.match(BUNDLE_ID_MATCH)[1];
 
@@ -166,25 +165,26 @@ function patchDesktopFile(desktopFileContent) {
   }
 
   return new Promise((resolve, reject) => {
-    if (fs.existsSync(desktopFilePath)) {
-      fs.readFile(desktopFilePath, 'utf8', (err, originalContent) => {
+    if (!fs.existsSync(desktopFilePath)) {
+      return resolve();
+    }
+    
+    fs.readFile(desktopFilePath, 'utf8', (err, originalContent) => {
+      if (err) {
+        return reject(err);
+      }
+
+      originalContent = originalContent
+        .replace(VERSION_MATCH, 'X-AppImage-Version=' + version)
+        .replace(BUNDLE_ID_MATCH, 'X-AppImage-BuildId=' + bundleId);
+
+      fs.writeFile(desktopFilePath, originalContent, (err) => {
         if (err) {
           return reject(err);
         }
 
-        originalContent = originalContent
-          .replace(VERSION_MATCH, 'X-AppImage-Version=' + version)
-          .replace(BUNDLE_ID_MATCH, 'X-AppImage-BuildId=' + bundleId);
-
-        fs.writeFile(desktopFilePath, originalContent, (err) => {
-          if (err) {
-            return reject(err);
-          }
-
-          resolve();
-        });
+        resolve();
       });
-    }
-    resolve();
+    });
   });
 }


### PR DESCRIPTION
Update functionality throws an error if AppImage .desktop file is not present,
Which might happen due to two reasons:
1. User pressed "No" during first launch and .desktop file was not created
2. File was deleted or removed afterwards

This patch checks for .desktop file and continues normally if it is not present.