### PR TITLE
Add important notes about Squirrel.Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ You can find a sample of updates.json in the [the example](example)
 
 2. Build your release using electron-builder or another tool.
 Note: Your application must be signed for automatic updates on macOS.
-This is a requirement of Squirrel.Mac
+This is a requirement of Squirrel.Mac.
 
 3. Upload your release with update.json to a hosting. You can 
-do it [manually](blob/master/example/updates.json) or use
+do it [manually](example/updates.json) or use
 [electron-simple-publisher](https://github.com/megahertz/electron-simple-publisher)
-to simplify this process.
+to simplify this process. Note: Squirrel.Mac requires a properly prepared `release.json` file. A release in the property `url` must be zipped .app file.
 
 4. That's it!
 

--- a/example/README.md
+++ b/example/README.md
@@ -6,7 +6,7 @@ This example uses
 [electron-builder](https://github.com/electron-userland/electron-builder)
 for building installer and update package and 
 [electron-simple-publisher](https://github.com/megahertz/electron-simple-publisher)
-to simplify release publishing
+to simplify release publishing.
 
 It can be built and published by the single command:
 
@@ -16,3 +16,5 @@ where `-- --` allows to pass arguments through npm.
 
 Also you can save github api token to publisher.json if you use
 a private repository.
+
+If you want to prepare a `updates.json` file manually remember that Squirrel.Mac requires a properly prepared `release.json` file. A release in the property `url` must be zipped .app file.


### PR DESCRIPTION
If you know more about the process of manually preparing updates.json and release.json files please add notes. I can't use 'electron-simple-publisher' because I store releases at the Firebase.