### PR TITLE
Unlink downloaded file on error status

### DIFF
--- a/src/utils/HttpClient.js
+++ b/src/utils/HttpClient.js
@@ -40,7 +40,7 @@ class HttpClient {
         allowRedirects: true,
       };
 
-      request.doRequest(options, (err, res) => {
+      request.doRequest(options, async (err, res) => {
         if (err) {
           return reject(err);
         }

--- a/src/utils/HttpClient.js
+++ b/src/utils/HttpClient.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const request = require('httpreq');
+const fs = require('fs');
 
 class HttpClient {
   /**
@@ -45,6 +46,7 @@ class HttpClient {
         }
 
         if (res.statusCode !== 200) {
+          await fs.promises.unlink(savePath);
           return reject(new Error(`Wrong HTTP status: ${res.statusCode}`));
         }
 


### PR DESCRIPTION
Currently when getting an http error code while downloading an update, an error is thrown, but the file is not deleted. This "file" will just be the test returned with the error status. 

The problem is that the next time you check for updates, electron-simple-updater thinks it's a valid file and may attempt to install it.

Fixed by deleting file on error.